### PR TITLE
 defined internal key used for sorting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,4 +9,8 @@ add_executable(lsm_engine
         main.cpp
         core/Entry.cpp
         core/Entry.h
+        core/value_type.h
+        core/internal_key.cpp
+        core/internal_key.h
+        core/internal_key_comparator.h
 )

--- a/core/Entry.cpp
+++ b/core/Entry.cpp
@@ -4,10 +4,18 @@
 
 #include "Entry.h"
 
+inline const char* value_type_to_string(ValueType t) {
+    switch (t) {
+        case ValueType::PUT:    return "PUT";
+        case ValueType::DELETE: return "DELETE";
+    }
+    return "UNKNOWN";
+}
+
 std::ostream& operator<<(std::ostream& os, const Entry& e) {
-    os << "key: " << e.key.bytes()
+    os << "key: " << e.ikey.user_key().bytes()
        << ", value: " << e.value.bytes()
-       << ", seq: " << e.seq
-       << ", tombstone: " << e.tombstone;
+       << ", seq: " << e.ikey.sequence()
+    << ", type: " << value_type_to_string(e.ikey.type());
     return os;
 }

--- a/core/Entry.h
+++ b/core/Entry.h
@@ -4,28 +4,27 @@
 
 #ifndef ENTRY_H
 #define ENTRY_H
-#include "key.h"
 #include "value.h"
+#include "internal_key.h"
 
 
 class Entry {
 
-    Key key;
+    InternalKey ikey;
     Value value;
-    uint64_t seq{};
-    // soft delete feature using tombstone
-    bool tombstone{};
 
 public:
 
     Entry(Key key,
-      Value value,
-      uint64_t seq,
-      bool tombstone)
-    : key(std::move(key)),
-      value(std::move(value)),
-      seq(seq),
-      tombstone(tombstone) {}
+          Value value,
+          uint64_t seq,
+          bool tombstone)
+        : ikey(
+              std::move(key),
+              seq,
+              tombstone ? ValueType::DELETE : ValueType::PUT
+          ),
+          value(std::move(value)) {}
 
 
     // Declare friend for access to private members

--- a/core/internal_key.cpp
+++ b/core/internal_key.cpp
@@ -1,0 +1,15 @@
+//
+// Created by Samarth Mahendra on 2/13/26.
+//
+
+#include <ostream>
+#include "internal_key.h"
+
+std::ostream& operator<<(std::ostream& os, const InternalKey& k) {
+    os << "InternalKey("
+       << k.user_key().bytes()
+       << ", seq=" << k.sequence()
+       << ", type=" << (k.type() == ValueType::PUT ? "PUT" : "DELETE")
+       << ")";
+    return os;
+}

--- a/core/internal_key.h
+++ b/core/internal_key.h
@@ -1,0 +1,35 @@
+//
+// Created by Samarth Mahendra on 2/13/26.
+//
+
+#ifndef INTERNAL_KEY_H
+#define INTERNAL_KEY_H
+
+
+#pragma once
+
+#include <cstdint>
+#include "key.h"
+#include "value_type.h"
+
+class InternalKey {
+public:
+    InternalKey(Key user_key,
+                uint64_t sequence,
+                ValueType type)
+        : user_key_(std::move(user_key)),
+          sequence_(sequence),
+          type_(type) {}
+
+    const Key& user_key() const { return user_key_; }
+    uint64_t sequence() const { return sequence_; }
+    ValueType type() const { return type_; }
+
+private:
+    Key user_key_;
+    uint64_t sequence_;
+    ValueType type_;
+};
+
+
+#endif //INTERNAL_KEY_H

--- a/core/internal_key_comparator.h
+++ b/core/internal_key_comparator.h
@@ -1,0 +1,31 @@
+//
+// Created by Samarth Mahendra on 2/13/26.
+//
+
+#ifndef INTERNAL_KEY_COMPARATOR_H
+#define INTERNAL_KEY_COMPARATOR_H
+
+#pragma once
+#include "internal_key.h"
+
+struct InternalKeyComparator {
+    bool operator()(const InternalKey& a,
+                    const InternalKey& b) const {
+
+        // 1. Order by user key (ascending)
+        if (a.user_key().bytes() != b.user_key().bytes()) {
+            return a.user_key().bytes() < b.user_key().bytes();
+        }
+
+        // 2. For same user key, newer versions first
+        if (a.sequence() != b.sequence()) {
+            return a.sequence() > b.sequence(); // DESC
+        }
+
+        // 3. Optional: DELETE before PUT for same seq
+        return a.type() > b.type();
+    }
+};
+
+
+#endif //INTERNAL_KEY_COMPARATOR_H

--- a/core/value_type.h
+++ b/core/value_type.h
@@ -1,0 +1,15 @@
+//
+// Created by Samarth Mahendra on 2/13/26.
+//
+
+#ifndef VALUE_TYPE_H
+#define VALUE_TYPE_H
+#pragma once
+#include <cstdint>
+
+enum class ValueType : uint8_t {
+    PUT = 0,
+    DELETE = 1
+};
+
+#endif //VALUE_TYPE_H


### PR DESCRIPTION
Introduce an InternalKey abstraction to represent the engine’s internal ordering semantics, combining the user key with versioning metadata required for MVCC.

This issue defines how keys are ordered, compared, and made visible across MemTable, SSTables, and compaction. It intentionally separates user intent (Key) from storage/versioning policy (InternalKey).