### PR TITLE
 added wal, with replay and also apply function to memtable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,4 +15,6 @@ add_executable(lsm_engine
         core/types/internal_key_comparator.h
         core/memtable/MemTable.cpp
         core/memtable/MemTable.h
+        core/wal/Wal.cpp
+        core/wal/Wal.h
 )

--- a/core/memtable/MemTable.cpp
+++ b/core/memtable/MemTable.cpp
@@ -45,6 +45,15 @@ std::optional<Value> MemTable::get(const Key& user_key) const {
     return it->second;
 }
 
+void MemTable::apply(const Entry& entry) {
+    if (entry.ikey.type() == ValueType::PUT) {
+        put(entry.ikey.user_key(), entry.value, entry.ikey.sequence());
+    } else {
+        remove(entry.ikey.user_key(), entry.ikey.sequence());
+    }
+}
+
+
 size_t MemTable::size() const {
     return table_.size();
 }

--- a/core/memtable/MemTable.h
+++ b/core/memtable/MemTable.h
@@ -19,7 +19,7 @@ public:
     void put(Key key, Value value, uint64_t seq);
     void remove(Key key, uint64_t seq);
     std::optional<Value> get(const Key& key) const;
-
+    void apply(const Entry& entry);
     size_t size() const;
 
 private:

--- a/core/types/Entry.h
+++ b/core/types/Entry.h
@@ -10,10 +10,9 @@
 
 class Entry {
 
+public:
     InternalKey ikey;
     Value value;
-
-public:
 
     Entry(Key key,
           Value value,

--- a/core/wal/Wal.cpp
+++ b/core/wal/Wal.cpp
@@ -1,0 +1,88 @@
+//
+// Created by Samarth Mahendra on 2/14/26.
+//
+
+#include "Wal.h"
+#include "../types/Entry.h"
+
+
+Wal::Wal(const std::string &path): path_(path) {
+    out_.open(path_, std::ios::binary | std::ios::app);
+}
+
+
+void Wal::append(Entry &entry) {
+    if (!out_.is_open()) return;
+    //
+    // | seq (uint64) |
+    // | type (uint8) |
+    // | key_size (uint32) |
+    // | key bytes |
+    // | value_size (uint32) |
+    // | value bytes |
+
+    const auto& ikey = entry.ikey;
+    const auto& key_data = ikey.user_key().bytes();
+    const auto& value_data = entry.value.bytes();
+
+    uint64_t seq = ikey.sequence();
+    auto type = static_cast<uint8_t>(ikey.type());
+    auto key_size = static_cast<uint32_t>(key_data.size());
+    auto val_size = static_cast<uint32_t>(value_data.size());
+
+    // writing to buffer
+    //
+    out_.write(reinterpret_cast<char*>(&seq), sizeof(seq));
+    out_.write(reinterpret_cast<char*>(&type), sizeof(type));
+    out_.write(reinterpret_cast<char*>(&key_size), sizeof(key_size));
+    out_.write(key_data.data(), key_size);
+    out_.write(reinterpret_cast<char*>(&val_size), sizeof(val_size));
+    out_.write(value_data.data(), val_size);
+
+    out_.flush();
+}
+
+
+
+vector<Entry> Wal::replay() {
+    vector<Entry> entries;
+
+    ifstream in(path_, ios::binary);
+    if (!in.is_open()) return entries;
+
+    while (true){
+        uint64_t seq;
+        uint8_t type;
+        uint32_t key_size;
+        uint32_t val_size;
+
+        if (!in.read(reinterpret_cast<char*>(&seq), sizeof(seq))) break;
+        if (!in.read(reinterpret_cast<char*>(&type), sizeof(type))) break;
+        if (!in.read(reinterpret_cast<char*>(&key_size), sizeof(key_size))) break;
+
+        string key_buf(key_size, '\0');
+        if (!in.read(key_buf.data(), key_size)) break;
+
+        if (!in.read(reinterpret_cast<char*>(&val_size), sizeof(val_size))) break;
+
+        string val_buf(val_size, '\0');
+        if (!in.read(val_buf.data(), val_size)) break;
+
+        ValueType vtype =
+            (type == static_cast<uint8_t>(ValueType::DELETE))
+            ? ValueType::DELETE
+            : ValueType::PUT;
+        Entry e(
+            Key(key_buf),
+            Value(val_buf),
+            seq,
+            vtype == ValueType::DELETE
+        );
+
+        entries.push_back(std::move(e));
+
+    }
+    return entries;
+}
+
+

--- a/core/wal/Wal.h
+++ b/core/wal/Wal.h
@@ -1,0 +1,33 @@
+//
+// Created by Samarth Mahendra on 2/14/26.
+//
+
+#ifndef WAL_H
+#define WAL_H
+
+#pragma once
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "../types/Entry.h"
+
+
+class Wal {
+
+public:
+    explicit Wal(const std::string& path);
+
+    void append(Entry& entry);
+
+    vector<Entry> replay();
+
+private:
+    ofstream out_;
+    string path_;
+};
+
+
+
+#endif //WAL_H


### PR DESCRIPTION
This PR introduces a minimal but correct Write-Ahead Log (WAL) implementation for the LSM engine.
It provides durability for write operations and enables recovery by replaying log records into the MemTable on restart.

The WAL uses a length-prefixed binary record format to support deterministic parsing and crash-safe recovery.